### PR TITLE
Add missing :cache-dir property in generated .ensime file

### DIFF
--- a/maker/src/maker/project/EnsimeGenerator.scala
+++ b/maker/src/maker/project/EnsimeGenerator.scala
@@ -16,6 +16,7 @@ class EnsimeGenerator(props: MakerProps) {
       writer.append("  :java-home \"" + props.JavaHome().getAbsolutePath + "\"\n")
 
       writer.append("  :root-dir \"" + root.getAbsolutePath + "\"\n")
+      writer.append("  :cache-dir \"" + root.getAbsolutePath + "ensime_cache\"\n")
       writer.append("  :name \"" + name + "\"\n")
 
       // Scala library is shared between all modules


### PR DESCRIPTION
Hi Alex,

This PR adds a missing `:cache-dir` required property in `.ensime` generated file.

Cheers,
syl20bnr
